### PR TITLE
Add forbid-submodules

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 9726420c7a071e8cb233a066d36bc074b593a40f0b1b491d1b75aafa55390703
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - check-added-large-files = pre_commit_hooks.check_added_large_files:main
@@ -39,6 +39,7 @@ build:
     - fix-byte-order-marker = pre_commit_hooks.fix_byte_order_marker:main
     - fix-encoding-pragma = pre_commit_hooks.fix_encoding_pragma:main
     - forbid-new-submodules = pre_commit_hooks.forbid_new_submodules:main
+    - forbid-submodules = pre_commit_hooks.forbid_submodules:main
     - mixed-line-ending = pre_commit_hooks.mixed_line_ending:main
     - name-tests-test = pre_commit_hooks.tests_should_end_in_test:main
     - no-commit-to-branch = pre_commit_hooks.no_commit_to_branch:main
@@ -88,6 +89,7 @@ test:
     - fix-byte-order-marker --help
     - fix-encoding-pragma --help
     - forbid-new-submodules --help
+    - forbid-submodules --help
     - mixed-line-ending --help
     - name-tests-test --help
     - no-commit-to-branch --help


### PR DESCRIPTION
This adds the command `forbid-submodules` that was added in version [4.4.0](https://github.com/pre-commit/pre-commit-hooks/compare/v4.3.0...v4.4.0).
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
